### PR TITLE
Add support for non-numeric checksums

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - jruby-18mode
+  - jruby-19mode
+  - rbx-2.1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
-  - jruby-18mode
   - jruby-19mode
   - rbx-2.1.1

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,7 @@
 = Ruby class for handling basic Luhn number generation and verification
 
+{<img src="https://travis-ci.org/abletech/ruby_luhn.png" />}[https://travis-ci.org/abletech/ruby_luhn]
+
 Includes a class to handle Swedish civic numbers (Personnummer)
 That interface supports checking validity (length, valid date and satisfies luhn),
 returning the sex, the control digit and generating random civic numbers.

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 = Ruby class for handling basic Luhn number generation and verification
 
-{<img src="https://travis-ci.org/abletech/ruby_luhn.png" />}[https://travis-ci.org/abletech/ruby_luhn]
+{<img src="https://travis-ci.org/AbleTech/ruby_luhn.png" />}[https://travis-ci.org/AbleTech/ruby_luhn]
 
 Includes a class to handle Swedish civic numbers (Personnummer)
 That interface supports checking validity (length, valid date and satisfies luhn),

--- a/README.rdoc
+++ b/README.rdoc
@@ -30,6 +30,18 @@ returning the sex, the control digit and generating random civic numbers.
   '391030-3183'.civic_number? # true
   3910303183.civic_number?    # true
 
+== Luhn Mod N (from http://en.wikipedia.org/wiki/Luhn_mod_N_algorithm)
+
+The Luhn mod N algorithm is an extension to the Luhn algorithm that allows it to
+work with sequences of non-numeric characters. This can be useful when a check digit
+is required to validate an identification string composed of letters, a combination
+of letters and digits or even any arbitrary set of characters.
+
+  luhnModN = Luhn::LuhnModN.new('ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+  luhnModN.generate('ABC') # 'ABCV'
+  luhnModN.valid?('ABDV') # true
+  luhnModN.check_character('ABC') # 'V'
+
 == About the Luhn algorithm (from http://en.wikipedia.org/wiki/Luhn_formula)
 
 The Luhn algorithm or Luhn formula, also known as the "modulus 10" or "mod 10"

--- a/lib/luhn.rb
+++ b/lib/luhn.rb
@@ -24,15 +24,12 @@ module Luhn
 
     def checksum(value, operation)
       i = 0
-      value.reverse.split(//).inject(0) do |sum, c|
+      compare_method = (operation == :even) ? :== : :>
+      value.reverse.split('').inject(0) do |sum, c|
         n = c.to_i
-        calc = if operation == :even
-          (i % 2 == 0) ? n * 2 : n
-        else
-          (i % 2 != 0) ? n * 2 : n
-        end
+        weight = (i % 2).send(compare_method, 0) ? n * 2 : n
         i += 1
-        sum += calc <= 9 ? calc : (calc % 10) + 1
+        sum += weight < 10 ? weight : weight - 9
       end
     end
   end

--- a/lib/luhn.rb
+++ b/lib/luhn.rb
@@ -3,6 +3,7 @@ require 'luhn/extensions'
 
 module Luhn
   autoload :CivicNumber, 'luhn/civic_number'
+  autoload :LuhnModN, 'luhn/luhn_mod_n'
 
   class << self
     def valid?(value)

--- a/lib/luhn/luhn_mod_n.rb
+++ b/lib/luhn/luhn_mod_n.rb
@@ -1,0 +1,67 @@
+# Algorithm based on http://en.wikipedia.org/wiki/Luhn_mod_N_algorithm
+module Luhn
+  class LuhnModN
+    def initialize(valid_characters)
+      @valid_characters = valid_characters
+    end
+
+    def valid?(string_including_check_char)
+      string = cleanup_string(string_including_check_char)
+      chk_ch = string.slice!(-1)
+
+      # assert the chk_ch
+      raise_error_if_check_character_is_not_valid(chk_ch)
+
+      check_character(string) == chk_ch
+    end
+
+    def generate(string_without_check_char)
+      string_without_check_char + check_character(string_without_check_char)
+    end
+
+    def check_character(input_string)
+      factor = 2;
+      sum = 0;
+      n = @valid_characters.size
+
+      # Starting from the right and working leftwards is easier since
+      # the initial "factor" will always be "2"
+      input_string.reverse.each_char do |character|
+        code_point = code_point_from_character(character)
+        addend = factor * code_point
+
+        # Alternate the "factor" that each "codePoint" is multiplied by
+        factor = (factor == 2) ? 1 : 2
+
+        # Sum the digits of the "addend" as expressed in base "n"
+        addend = (addend / n) + (addend % n);
+        sum += addend;
+      end
+
+      # Calculate the number that must be added to the "sum"
+      # to make it divisible by "n"
+      remainder = sum % n;
+      check_code_point = (n - remainder) % n;
+
+      character_from_code_point(check_code_point);
+    end
+
+    protected
+
+    def raise_error_if_check_character_is_not_valid(chk_ch)
+      code_point_from_character(chk_ch)
+    end
+
+    def code_point_from_character(ch)
+      @valid_characters.index(ch) || raise("Unsupported character '#{ch}'")
+    end
+
+    def character_from_code_point(code_point)
+      @valid_characters[code_point]
+    end
+
+    def cleanup_string(string)
+      string.gsub(/\s/, '')
+    end
+  end
+end

--- a/luhn.gemspec
+++ b/luhn.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.homepage     = 'http://github.com/joeljunstrom/ruby_luhn'
   s.summary      = 'A small implementation of the Luhn algorithm.'
   s.require_path = 'lib'
-  s.authors      = ['Joel Junström']
-  s.email        = ['joel.junstrom@gmail.com']
+  s.authors      = ['Joel Junström', 'Nigel Ramsay']
+  s.email        = ['joel.junstrom@gmail.com', 'nigel.ramsay@abletech.co.nz']
   s.version      = Luhn::Version
   s.platform     = Gem::Platform::RUBY
   s.files        = Dir.glob("{lib,spec}/**/*") + %w[LICENSE README.rdoc]

--- a/spec/spec_luhn_mod_n.rb
+++ b/spec/spec_luhn_mod_n.rb
@@ -1,0 +1,41 @@
+require 'helper'
+
+describe Luhn::LuhnModN do
+  let(:valid_characters){ ('A'..'Z').to_a }
+
+  before do
+    @luhn_mod_n = Luhn::LuhnModN.new(valid_characters.join)
+  end
+
+  it 'calculates the check_character' do
+    @luhn_mod_n.check_character('ABC').must_equal 'V'
+  end
+
+  it "identifies if the string is valid" do
+    @luhn_mod_n.valid?('ABCV').must_equal true
+  end
+
+  it "identifies if the string is valid (ingoring the whitespace)" do
+    @luhn_mod_n.valid?("ABCV\n").must_equal true
+    @luhn_mod_n.valid?('ABCV ').must_equal true
+    @luhn_mod_n.valid?(' ABCV').must_equal true
+  end
+
+  it "identifies if the string is invalid" do
+    @luhn_mod_n.valid?('ABCX').must_equal false
+  end
+
+  it 'generates a string that satisfies luhn mod n' do
+    random_string = valid_characters.sample(6).join
+    generated_string = @luhn_mod_n.generate(random_string)
+    @luhn_mod_n.valid?(generated_string).must_equal true
+  end
+
+  it 'raises an exception for a unsupported check character' do
+    proc { @luhn_mod_n.valid?('ABC9') }.must_raise(RuntimeError)
+  end
+
+  it 'raises an exception for a unsupported character' do
+    proc { @luhn_mod_n.valid?('9ABC') }.must_raise(RuntimeError)
+  end
+end


### PR DESCRIPTION
Hi Joel,

I wanted to create a checksum character for some non-numeric strings. I found the Luhn Mod N algorithm on Wikipedia, and have applied it to your project. I have tried to follow a similar approach to what you've done with  Swedish CivicNumber class. 

Here's the algorithm, which is very similar to the Luhn algorithm. 

http://en.wikipedia.org/wiki/Luhn_mod_N_algorithm

I think the "Luhn Mod N" class (and specs) would be a useful addition to your gem. 

Cheers,

Nigel